### PR TITLE
Specify custom OpenAI API by OPENAI_BASE_URL env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ codey
 ## Configuration
 Set environment variables or use a local `.env` file:
 - `OPENAI_API_KEY` (required)
+- `OPENAI_BASE_URL` (optional) - Custom OpenAI-compatible API base URL
 - `MODEL_NAME` (optional)
 - `PROMPT_PATH` (optional)
 

--- a/codey/config.py
+++ b/codey/config.py
@@ -8,6 +8,7 @@ load_dotenv()
 
 API_KEY_ENV = "OPENAI_API_KEY"
 OPENAI_API_KEY = os.getenv(API_KEY_ENV)
+OPENAI_BASE_URL = os.getenv("OPENAI_BASE_URL")  # Optional custom base URL
 if not OPENAI_API_KEY:
     raise RuntimeError(f"Please set the {API_KEY_ENV} environment variable")
 
@@ -43,4 +44,7 @@ SHOW_TOOL_RESULTS = os.getenv("SHOW_TOOL_RESULTS", "false").lower() == "true"
 SHOW_SYSTEM_PROMPT = True
 
 # Initialize OpenAI client
-client = OpenAI(api_key=OPENAI_API_KEY)
+if OPENAI_BASE_URL:
+    client = OpenAI(api_key=OPENAI_API_KEY, base_url=OPENAI_BASE_URL)
+else:
+    client = OpenAI(api_key=OPENAI_API_KEY)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,6 +6,7 @@ Before using Codey, it's essential to set up your environment correctly. The fol
 To function properly, Codey requires certain environment variables to be set:
 
 - **OPENAI_API_KEY**: This is required for accessing AI functionalities. You can obtain an API key by signing up at OpenAI's website.
+- **OPENAI_BASE_URL** (optional): Specify a custom OpenAI-compatible API base URL. If not set, Codey will use the default OpenAI API endpoint.
 - **MODEL_NAME** (optional): Specify the AI model you wish to use. If not set, Codey will default to a specified model.
 
 ## Setting Up Environment Variables
@@ -15,12 +16,14 @@ To set environment variables, you can do so directly in your terminal or use a `
 For Unix-based systems (Linux, macOS), you can export the variables as follows:
 ```bash
 export OPENAI_API_KEY='your_api_key'
+export OPENAI_BASE_URL='https://your-custom-openai-server.com/v1'  # Optional
 export MODEL_NAME='your_model_name'
 ```
 
 For Windows:
 ```cmd
 set OPENAI_API_KEY='your_api_key'
+set OPENAI_BASE_URL='https://your-custom-openai-server.com/v1'  # Optional
 set MODEL_NAME='your_model_name'
 ```
 
@@ -28,6 +31,7 @@ set MODEL_NAME='your_model_name'
 You can also create a `.env` file in your project root with the following format:
 ```
 OPENAI_API_KEY=your_api_key
+OPENAI_BASE_URL=https://your-custom-openai-server.com/v1  # Optional
 MODEL_NAME=your_model_name
 ```
 


### PR DESCRIPTION
# Add Support for Custom OpenAI-Compatible Servers

## Summary
This PR adds support for connecting to custom OpenAI-compatible API servers through a configurable base URL environment variable. This enables users to connect to self-hosted OpenAI APIs, alternative providers, or local development servers.

## Changes Made

### Core Implementation
- **`codey/config.py`**: Added `OPENAI_BASE_URL` environment variable support
  - Modified OpenAI client initialization to use custom base URL when provided
  - Maintains backward compatibility with default OpenAI API endpoint
  - Falls back gracefully if no custom URL is specified

### Documentation Updates
- **`docs/configuration.md`**: Added comprehensive documentation for the new environment variable
  - Included usage examples for Unix/macOS, Windows, and `.env` file configurations
  - Provided example custom server URLs
- **`README.md`**: Updated configuration section to include the new optional parameter

## Usage
Users can now specify a custom OpenAI server by setting the `OPENAI_BASE_URL` environment variable:

```bash
export OPENAI_BASE_URL='https://your-custom-openai-server.com/v1'
export OPENAI_API_KEY='your-api-key'
codey
```