### PR TITLE
feat: tool approval, Ctrl+C interrupt, token/cost tracking, provider auto-detect, fix update

### DIFF
--- a/codey/__init__.py
+++ b/codey/__init__.py
@@ -1,2 +1,2 @@
 # Codey package initializer
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/codey/chat_runner.py
+++ b/codey/chat_runner.py
@@ -105,14 +105,15 @@ def truncate_args(args):
 
 
 def call_tool(name, args):
-    """Safely call a tool, with optional shell-command confirmation."""
-    if name == "shell" and CONFIRM_SHELL:
-        cmd = args.get("command", "")
-        sys.stdout.write(f"{TOOL_COLOR}Shell: {cmd}{RESET}\nExecute? [y/N] ")
-        sys.stdout.flush()
+    """Safely call a tool, always asking for user approval before executing."""
+    sys.stdout.write(f"{TOOL_COLOR}Tool: {name}({truncate_args(args)}){RESET}\nApprove? [y/N] ")
+    sys.stdout.flush()
+    try:
         answer = sys.stdin.readline().strip().lower()
-        if answer != "y":
-            return "Command execution cancelled by user."
+    except (EOFError, KeyboardInterrupt):
+        return "Command execution cancelled by user."
+    if answer != "y":
+        return "Command execution cancelled by user."
 
     if SHOW_TOOL_CALLS:
         print(f"{TOOL_COLOR}Tool call: {name}({truncate_args(args)}){RESET}")
@@ -157,6 +158,8 @@ def process_history(history, model=MODEL_NAME):
     if _estimate_size(history) > CONTEXT_CACHE_THRESHOLD:
         history = _compress_context(history, model)
 
+    total_usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}
+
     for _ in range(MAX_TOOL_ROUNDS):
         stream = client.chat.completions.create(
             model=model,
@@ -164,36 +167,53 @@ def process_history(history, model=MODEL_NAME):
             tools=_active_tools(),
             tool_choice="auto",
             stream=True,
+            stream_options={"include_usage": True},
         )
 
         content_parts = []
         tool_calls_map = {}   # index -> {id, name, arguments}
         printed_prefix = False
 
-        for chunk in stream:
-            if not chunk.choices:
-                continue
-            delta = chunk.choices[0].delta
+        try:
+            for chunk in stream:
+                if getattr(chunk, "usage", None):
+                    u = chunk.usage
+                    total_usage["prompt_tokens"]     += getattr(u, "prompt_tokens", 0) or 0
+                    total_usage["completion_tokens"] += getattr(u, "completion_tokens", 0) or 0
+                    total_usage["total_tokens"]      += getattr(u, "total_tokens", 0) or 0
+                    # OpenRouter includes cost (USD) on the usage object
+                    cost = getattr(u, "cost", None) or (
+                        u.model_extra.get("cost") if getattr(u, "model_extra", None) else None
+                    )
+                    if cost is not None:
+                        total_usage["cost"] += float(cost)
+                if not chunk.choices:
+                    continue
+                delta = chunk.choices[0].delta
 
-            if delta.content:
-                if not printed_prefix:
-                    print(f"\n{CODEY_COLOR}Codey: ", end="", flush=True)
-                    printed_prefix = True
-                print(delta.content, end="", flush=True)
-                content_parts.append(delta.content)
+                if delta.content:
+                    if not printed_prefix:
+                        print(f"\n{CODEY_COLOR}Codey: ", end="", flush=True)
+                        printed_prefix = True
+                    print(delta.content, end="", flush=True)
+                    content_parts.append(delta.content)
 
-            if delta.tool_calls:
-                for tc in delta.tool_calls:
-                    idx = tc.index
-                    if idx not in tool_calls_map:
-                        tool_calls_map[idx] = {"id": "", "name": "", "arguments": ""}
-                    if tc.id:
-                        tool_calls_map[idx]["id"] = tc.id
-                    if tc.function:
-                        if tc.function.name:
-                            tool_calls_map[idx]["name"] += tc.function.name
-                        if tc.function.arguments:
-                            tool_calls_map[idx]["arguments"] += tc.function.arguments
+                if delta.tool_calls:
+                    for tc in delta.tool_calls:
+                        idx = tc.index
+                        if idx not in tool_calls_map:
+                            tool_calls_map[idx] = {"id": "", "name": "", "arguments": ""}
+                        if tc.id:
+                            tool_calls_map[idx]["id"] = tc.id
+                        if tc.function:
+                            if tc.function.name:
+                                tool_calls_map[idx]["name"] += tc.function.name
+                            if tc.function.arguments:
+                                tool_calls_map[idx]["arguments"] += tc.function.arguments
+        except KeyboardInterrupt:
+            if printed_prefix:
+                print(RESET, flush=True)
+            raise
 
         if printed_prefix:
             print(RESET, flush=True)
@@ -248,9 +268,9 @@ def process_history(history, model=MODEL_NAME):
 
         # No tool calls — this is the final response
         history.append({"role": "assistant", "content": content})
-        return history, content
+        return history, content, total_usage
 
     msg = f"[Stopped after {MAX_TOOL_ROUNDS} tool-call rounds]"
     print(f"{TOOL_COLOR}{msg}{RESET}")
     history.append({"role": "assistant", "content": msg})
-    return history, msg
+    return history, msg, total_usage

--- a/codey/cli.py
+++ b/codey/cli.py
@@ -13,8 +13,8 @@ from prompt_toolkit.key_binding import KeyBindings
 
 from . import __version__
 from .chat_runner import process_history
-from .config import MODEL_NAME, PROMPT_NAME, ENABLED_TOOLS
-from .persistence import list_sessions, load_session, new_session_path, save_messages
+from .config import MODEL_NAME, PROMPT_NAME, ENABLED_TOOLS, PROVIDER
+from .persistence import list_sessions, load_session, new_session_path, save_messages, load_session_meta, save_session_meta
 from .tools import TOOL_MAP
 from .update import check_for_update, format_update_notice, perform_update
 
@@ -198,10 +198,16 @@ def _pick_session(project_dir: str):
     for i, s in enumerate(sessions, 1):
         date_str = _fmt_date(s["mtime"])
         preview  = s["preview"]
-        if len(preview) > 52:
-            preview = preview[:52] + "…"
+        if len(preview) > 40:
+            preview = preview[:40] + "…"
         count_str = f"({s['count']} msgs)"
-        print(f"  {DIM}[{i}]{RESET} {date_str}  {DIM}{count_str:12}{RESET}  {preview}")
+        tok = s.get("tokens", {})
+        if tok.get("total_tokens"):
+            cost_part = f" ${tok['cost']:.4f}" if tok.get("cost") else ""
+            tok_str = f"  {DIM}in:{tok['prompt_tokens']} out:{tok['completion_tokens']} tot:{tok['total_tokens']}{cost_part}{RESET}"
+        else:
+            tok_str = ""
+        print(f"  {DIM}[{i}]{RESET} {date_str}  {DIM}{count_str:12}{RESET}  {preview}{tok_str}")
 
     print(f"\n  {DIM}[N]{RESET}  New session\n")
 
@@ -285,7 +291,22 @@ def main():
     history = [{"role": "system", "content": system_prompt}]
     history.extend(prior)
 
-    print(f"\n{TOOL_COLOR}Model: {MODEL_NAME}  Tools: {', '.join(active_tools)} — type 'exit' to quit{RESET}")
+    # Load any existing token counts for a resumed session
+    session_tokens = load_session_meta(session_path)
+    if not session_tokens:
+        session_tokens = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cost": 0.0}
+
+    def _print_token_summary():
+        t = session_tokens
+        if t["total_tokens"]:
+            cost_str = f"  cost: ${t['cost']:.6f}" if t.get("cost") else ""
+            print(
+                f"{TOOL_COLOR}Tokens — in: {t['prompt_tokens']}  "
+                f"out: {t['completion_tokens']}  "
+                f"total: {t['total_tokens']}{cost_str}{RESET}"
+            )
+
+    print(f"\n{TOOL_COLOR}Provider: {PROVIDER}  Model: {MODEL_NAME}  Tools: {', '.join(active_tools)} — type 'exit' to quit{RESET}")
     print(f"{TOOL_COLOR}Tip: paste a file path to attach it | type @image to attach clipboard image{RESET}\n")
 
     # Lazy-init now that we know we have a real console.
@@ -301,10 +322,12 @@ def main():
             )
         except (EOFError, KeyboardInterrupt):
             print("\nExiting.")
+            _print_token_summary()
             sys.exit(0)
 
         if text.strip().lower() in ("exit", "quit"):
             print("Goodbye!")
+            _print_token_summary()
             sys.exit(0)
 
         content = _build_content(text)
@@ -312,7 +335,21 @@ def main():
         start_idx = len(history)
         history.append({"role": "user", "content": content})
 
-        history, _ = process_history(history, MODEL_NAME)
+        try:
+            history, _, usage = process_history(history, MODEL_NAME)
+        except KeyboardInterrupt:
+            print(f"\n{TOOL_COLOR}[Interrupted — returning to prompt]{RESET}")
+            # Roll back the user message so the incomplete turn isn't saved
+            history = history[:start_idx]
+            print(f"{TOOL_COLOR}" + "-" * 60 + f"{RESET}\n")
+            continue
+
+        # Accumulate token usage for this session
+        if usage:
+            for k in ("prompt_tokens", "completion_tokens", "total_tokens"):
+                session_tokens[k] = session_tokens.get(k, 0) + usage.get(k, 0)
+            session_tokens["cost"] = session_tokens.get("cost", 0.0) + usage.get("cost", 0.0)
+            save_session_meta(session_path, session_tokens)
 
         save_messages(session_path, history[start_idx:])
 

--- a/codey/config.py
+++ b/codey/config.py
@@ -7,12 +7,35 @@ load_dotenv()
 
 API_KEY_ENV = "OPENAI_API_KEY"
 OPENAI_API_KEY = os.getenv(API_KEY_ENV)
-OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
 if not OPENAI_API_KEY:
     raise RuntimeError(f"Please set the {API_KEY_ENV} environment variable")
 
+# Auto-detect provider from key prefix; fall back to explicit env var
+_key = OPENAI_API_KEY.strip()
+if _key.startswith("sk-proj"):
+    _provider = "openai"
+elif _key.startswith("sk-or"):
+    _provider = "openrouter"
+else:
+    # Allow explicit override via PROVIDER env var
+    _provider = os.getenv("PROVIDER", "openrouter")
+
+if _provider == "openai":
+    OPENAI_BASE_URL = "https://api.openai.com/v1"
+    _default_model  = "gpt-4.1-mini"
+    _default_prompt = "codey-unlocked.txt"
+else:
+    OPENAI_BASE_URL = "https://openrouter.ai/api/v1"
+    _default_model  = "minimax/minimax-m3"
+    _default_prompt = "codey-unlocked.txt"
+
+PROVIDER = _provider
+
 PERSONAS = {
-    "gpt-5": {"model": os.getenv("UNLOCKED_MODEL", "minimax/minimax-m3"), "prompt": "codey-unlocked.txt"},
+    "gpt-5": {
+        "model":  os.getenv("UNLOCKED_MODEL", _default_model),
+        "prompt": _default_prompt,
+    },
 }
 
 DEFAULT_PERSONA = os.getenv("DEFAULT_PERSONA", "gpt-5")

--- a/codey/persistence.py
+++ b/codey/persistence.py
@@ -70,10 +70,34 @@ def _migrate_old_format(project_dir: str) -> None:
 
 # ── Public API ───────────────────────────────────────────────────────────────
 
+def _meta_path(session_path: Path) -> Path:
+    return session_path.with_suffix(".meta.json")
+
+
+def load_session_meta(session_path: Path) -> dict:
+    p = _meta_path(session_path)
+    if not p.exists():
+        return {}
+    try:
+        with open(p, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
+def save_session_meta(session_path: Path, meta: dict) -> None:
+    p = _meta_path(session_path)
+    try:
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(meta, f)
+    except Exception:
+        pass
+
+
 def list_sessions(project_dir: str) -> list:
     """
     Return sessions for this project sorted newest-first.
-    Each item: {path, mtime, count, preview}
+    Each item: {path, mtime, count, preview, tokens}
     """
     _migrate_old_format(project_dir)
     d = _sessions_dir(project_dir)
@@ -87,6 +111,7 @@ def list_sessions(project_dir: str) -> list:
             "mtime":   p.stat().st_mtime,
             "count":   len(msgs),
             "preview": _session_preview(msgs),
+            "tokens":  load_session_meta(p),
         })
     return sessions
 

--- a/codey/update.py
+++ b/codey/update.py
@@ -14,12 +14,10 @@ Only stdlib is used at runtime. packaging.version is used if available,
 otherwise a tiny tuple-comparison helper handles numeric versions.
 """
 
-import hashlib
 import json
 import os
 import subprocess
 import sys
-import tempfile
 import time
 import urllib.request
 import urllib.error
@@ -405,11 +403,7 @@ def perform_update(info=None):
         return True, "Already up to date (v{0}).".format(CURRENT_VERSION)
 
     new_v = info.get("version", "?")
-    wheel_url = info.get("wheel_url") or ""
-    expected_sha = info.get("wheel_sha256") or ""
-
-    if not wheel_url:
-        return False, "Update failed: release has no downloadable wheel."
+    pip_target = "git+https://github.com/Varad-13/codey.git@v{0}".format(new_v)
 
     _print_release_notes(info)
 
@@ -422,59 +416,18 @@ def perform_update(info=None):
     if answer not in ("y", "yes"):
         return False, "Update cancelled."
 
-    tmp_path = None
     try:
-        # Download to a temp file
-        fd, tmp_path_str = tempfile.mkstemp(suffix=".whl", prefix="codey-update-")
-        tmp_path = tmp_path_str
-        os.close(fd)
-        try:
-            with urllib.request.urlopen(wheel_url, timeout=30) as resp:
-                data = resp.read()
-        except Exception as e:
-            return False, "Update failed: download error ({0})".format(e)
-        try:
-            with open(tmp_path, "wb") as f:
-                f.write(data)
-        except Exception as e:
-            return False, "Update failed: could not save wheel ({0})".format(e)
+        proc = subprocess.run(
+            [sys.executable, "-m", "pip", "install", "--upgrade", pip_target],
+            capture_output=True,
+            text=True,
+        )
+    except Exception as e:
+        return False, "Update failed: pip could not be invoked ({0})".format(e)
 
-        # Verify SHA256 if we have it
-        if expected_sha:
-            try:
-                h = hashlib.sha256()
-                with open(tmp_path, "rb") as f:
-                    for chunk in iter(lambda: f.read(64 * 1024), b""):
-                        h.update(chunk)
-                got = h.hexdigest().lower()
-                want = expected_sha.lower()
-                if got != want:
-                    return False, (
-                        "Update failed: SHA256 mismatch "
-                        "(expected {0}, got {1})".format(want, got)
-                    )
-            except Exception as e:
-                return False, "Update failed: hash check error ({0})".format(e)
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout or "").strip().splitlines()
+        tail = err[-1] if err else "pip exited with code {0}".format(proc.returncode)
+        return False, "Update failed: {0}".format(tail)
 
-        # pip install --upgrade --force-reinstall
-        try:
-            proc = subprocess.run(
-                [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", tmp_path],
-                capture_output=True,
-                text=True,
-            )
-        except Exception as e:
-            return False, "Update failed: pip could not be invoked ({0})".format(e)
-
-        if proc.returncode != 0:
-            err = (proc.stderr or proc.stdout or "").strip().splitlines()
-            tail = err[-1] if err else "pip exited with code {0}".format(proc.returncode)
-            return False, "Update failed: {0}".format(tail)
-
-        return True, "Updated to v{0}. Restart Codey to use the new version.".format(new_v)
-    finally:
-        if tmp_path:
-            try:
-                os.unlink(tmp_path)
-            except Exception:
-                pass
+    return True, "Updated to v{0}. Restart Codey to use the new version.".format(new_v)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class DevelopWithPlaywright(_PlaywrightMixin, develop):
 
 setup(
     name='codey',
-    version='0.4.2',
+    version='0.4.3',
     packages=find_packages(include=['codey', 'codey.*']),
     include_package_data=True,
     install_requires=[


### PR DESCRIPTION
## Summary

- All tool calls now require `y/N` approval before executing (replaces shell-only confirm)
- `Ctrl+C` during agent loop interrupts the current turn and returns to prompt instead of exiting
- Token tracking: input/output/total tokens + cost (OpenRouter) accumulated per session, shown in picker and on exit
- Auto-detect provider from API key prefix (`sk-proj` → OpenAI + `gpt-4.1-mini`, `sk-or` → OpenRouter + `minimax/minimax-m3`)
- Fix `codey update` crash: was using a temp filename with wrong wheel format; now installs directly via `pip install git+https://github.com/Varad-13/codey.git@vX.Y.Z`
- Bumps version to 0.4.3

## Test plan

- [ ] Run with an OpenAI key (`sk-proj-...`) — confirm model is `gpt-4.1-mini` and base URL is `api.openai.com`
- [ ] Run with an OpenRouter key (`sk-or-...`) — confirm model is `minimax/minimax-m3`
- [ ] Send a message and verify approval prompt appears before each tool call; confirm `N` cancels
- [ ] Press `Ctrl+C` mid-response — confirm it returns to the `You:` prompt without exiting
- [ ] Run a few turns and `exit` — confirm token summary prints (cost only if OpenRouter)
- [ ] Start a new session, resume it — confirm token counts carry over from the picker
- [ ] Run `python -m codey update -y` — confirm it installs from the git tag without wheel filename error

🤖 Generated with [Claude Code](https://claude.com/claude-code)